### PR TITLE
Remove Gemini-2 archive

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -22,12 +22,8 @@ sites:
     url: "eu-2.gemini-3c.subspace.network"
   # perform easiest queries for GraphQL endpoints
   # for more details: https://www.apollographql.com/docs/apollo-server/monitoring/health-checks/#graphql-level-health-checks
-  - name: "Gemini-II Subsquid archive GraphQL endpoint"
-    url: "archive.gemini-2a.subspace.network/graphql?query=%7B__typename%7D"
   - name: "Gemini-II block explorer squid GraphQL endpoint"
     url: "squid.gemini-2a.subspace.network/graphql?query=%7B__typename%7D"
-  - name: "Gemini-II Subsquid archive API endpoint"
-    url: "archive.gemini-2a.subspace.network/api?query=%7B__typename%7D"
   - name: "Gemini-III block explorer squid GraphQL endpoint"
     url: "squid.gemini-3b.subspace.network/graphql?query=%7B__typename%7D"
   - name: "Gemini-III Subsquid archive API endpoint"

--- a/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/response-time-day.json
+++ b/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"804 ms","color":"orange"}
+{"schemaVersion":1,"label":"response time 24h","message":"616 ms","color":"yellow"}

--- a/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/response-time-week.json
+++ b/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"644 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 7d","message":"622 ms","color":"yellow"}

--- a/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/uptime-month.json
+++ b/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/uptime-month.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime 30d","message":"99.28%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime 30d","message":"99.29%","color":"brightgreen"}

--- a/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/uptime-year.json
+++ b/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/uptime-year.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime 1y","message":"99.28%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime 1y","message":"99.29%","color":"brightgreen"}

--- a/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/uptime.json
+++ b/api/gemini-ii-block-explorer-squid-graph-ql-endpoint/uptime.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime","message":"99.28%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime","message":"99.29%","color":"brightgreen"}

--- a/api/gemini-ii-eu-0-rpc-endpoint/response-time-day.json
+++ b/api/gemini-ii-eu-0-rpc-endpoint/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"179 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 24h","message":"151 ms","color":"brightgreen"}

--- a/api/gemini-ii-eu-0-rpc-endpoint/response-time-week.json
+++ b/api/gemini-ii-eu-0-rpc-endpoint/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"180 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 7d","message":"176 ms","color":"brightgreen"}

--- a/api/gemini-ii-eu-0-rpc-endpoint/uptime-month.json
+++ b/api/gemini-ii-eu-0-rpc-endpoint/uptime-month.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime 30d","message":"99.53%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime 30d","message":"99.54%","color":"brightgreen"}

--- a/api/gemini-ii-eu-0-rpc-endpoint/uptime-year.json
+++ b/api/gemini-ii-eu-0-rpc-endpoint/uptime-year.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime 1y","message":"99.53%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime 1y","message":"99.54%","color":"brightgreen"}

--- a/api/gemini-ii-eu-0-rpc-endpoint/uptime.json
+++ b/api/gemini-ii-eu-0-rpc-endpoint/uptime.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime","message":"99.53%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime","message":"99.54%","color":"brightgreen"}

--- a/api/gemini-iii-block-explorer-squid-graph-ql-endpoint/response-time-day.json
+++ b/api/gemini-iii-block-explorer-squid-graph-ql-endpoint/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"1019 ms","color":"red"}
+{"schemaVersion":1,"label":"response time 24h","message":"615 ms","color":"yellow"}

--- a/api/gemini-iii-block-explorer-squid-graph-ql-endpoint/response-time-week.json
+++ b/api/gemini-iii-block-explorer-squid-graph-ql-endpoint/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"654 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 7d","message":"626 ms","color":"yellow"}

--- a/api/gemini-iii-block-explorer-squid-graph-ql-endpoint/response-time-year.json
+++ b/api/gemini-iii-block-explorer-squid-graph-ql-endpoint/response-time-year.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 1y","message":"606 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 1y","message":"607 ms","color":"yellow"}

--- a/api/gemini-iii-block-explorer-squid-graph-ql-endpoint/response-time.json
+++ b/api/gemini-iii-block-explorer-squid-graph-ql-endpoint/response-time.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time","message":"606 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time","message":"607 ms","color":"yellow"}

--- a/api/gemini-iii-eu-0-rpc-endpoint/response-time-day.json
+++ b/api/gemini-iii-eu-0-rpc-endpoint/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"180 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 24h","message":"148 ms","color":"brightgreen"}

--- a/api/gemini-iii-eu-0-rpc-endpoint/response-time-week.json
+++ b/api/gemini-iii-eu-0-rpc-endpoint/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"148 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 7d","message":"144 ms","color":"brightgreen"}

--- a/api/gemini-iii-eu-1-rpc-endpoint/response-time-day.json
+++ b/api/gemini-iii-eu-1-rpc-endpoint/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"178 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 24h","message":"148 ms","color":"brightgreen"}

--- a/api/gemini-iii-eu-1-rpc-endpoint/response-time-week.json
+++ b/api/gemini-iii-eu-1-rpc-endpoint/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"153 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 7d","message":"149 ms","color":"brightgreen"}

--- a/api/gemini-iii-eu-2-rpc-endpoint/response-time-day.json
+++ b/api/gemini-iii-eu-2-rpc-endpoint/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"177 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 24h","message":"148 ms","color":"brightgreen"}

--- a/api/gemini-iii-eu-2-rpc-endpoint/response-time-month.json
+++ b/api/gemini-iii-eu-2-rpc-endpoint/response-time-month.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 30d","message":"167 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 30d","message":"166 ms","color":"brightgreen"}

--- a/api/gemini-iii-eu-2-rpc-endpoint/response-time-week.json
+++ b/api/gemini-iii-eu-2-rpc-endpoint/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"147 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 7d","message":"143 ms","color":"brightgreen"}

--- a/api/gemini-iii-eu-2-rpc-endpoint/response-time-year.json
+++ b/api/gemini-iii-eu-2-rpc-endpoint/response-time-year.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 1y","message":"165 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time 1y","message":"164 ms","color":"brightgreen"}

--- a/api/gemini-iii-eu-2-rpc-endpoint/response-time.json
+++ b/api/gemini-iii-eu-2-rpc-endpoint/response-time.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time","message":"165 ms","color":"brightgreen"}
+{"schemaVersion":1,"label":"response time","message":"164 ms","color":"brightgreen"}

--- a/api/gemini-iii-subsquid-archive-api-endpoint/response-time-day.json
+++ b/api/gemini-iii-subsquid-archive-api-endpoint/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"636 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 24h","message":"638 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-api-endpoint/response-time-month.json
+++ b/api/gemini-iii-subsquid-archive-api-endpoint/response-time-month.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 30d","message":"636 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 30d","message":"638 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-api-endpoint/response-time-week.json
+++ b/api/gemini-iii-subsquid-archive-api-endpoint/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"636 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 7d","message":"638 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-api-endpoint/response-time-year.json
+++ b/api/gemini-iii-subsquid-archive-api-endpoint/response-time-year.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 1y","message":"636 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 1y","message":"638 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-api-endpoint/response-time.json
+++ b/api/gemini-iii-subsquid-archive-api-endpoint/response-time.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time","message":"636 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time","message":"638 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-graph-ql-endpoint/response-time-day.json
+++ b/api/gemini-iii-subsquid-archive-graph-ql-endpoint/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"772 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 24h","message":"627 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-graph-ql-endpoint/response-time-week.json
+++ b/api/gemini-iii-subsquid-archive-graph-ql-endpoint/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"651 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 7d","message":"632 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-graph-ql-endpoint/response-time-year.json
+++ b/api/gemini-iii-subsquid-archive-graph-ql-endpoint/response-time-year.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 1y","message":"625 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time 1y","message":"626 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-graph-ql-endpoint/response-time.json
+++ b/api/gemini-iii-subsquid-archive-graph-ql-endpoint/response-time.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time","message":"625 ms","color":"yellow"}
+{"schemaVersion":1,"label":"response time","message":"626 ms","color":"yellow"}

--- a/api/gemini-iii-subsquid-archive-graph-ql-endpoint/uptime-day.json
+++ b/api/gemini-iii-subsquid-archive-graph-ql-endpoint/uptime-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime 24h","message":"98.83%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime 24h","message":"100%","color":"brightgreen"}

--- a/api/gemini-iii-subsquid-archive-graph-ql-endpoint/uptime-month.json
+++ b/api/gemini-iii-subsquid-archive-graph-ql-endpoint/uptime-month.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime 30d","message":"99.65%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime 30d","message":"99.66%","color":"brightgreen"}

--- a/api/gemini-iii-subsquid-archive-graph-ql-endpoint/uptime-year.json
+++ b/api/gemini-iii-subsquid-archive-graph-ql-endpoint/uptime-year.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime 1y","message":"99.65%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime 1y","message":"99.66%","color":"brightgreen"}

--- a/api/gemini-iii-subsquid-archive-graph-ql-endpoint/uptime.json
+++ b/api/gemini-iii-subsquid-archive-graph-ql-endpoint/uptime.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"uptime","message":"99.65%","color":"brightgreen"}
+{"schemaVersion":1,"label":"uptime","message":"99.66%","color":"brightgreen"}

--- a/api/subspace-labs-website/response-time-day.json
+++ b/api/subspace-labs-website/response-time-day.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 24h","message":"422 ms","color":"yellowgreen"}
+{"schemaVersion":1,"label":"response time 24h","message":"628 ms","color":"yellow"}

--- a/api/subspace-labs-website/response-time-month.json
+++ b/api/subspace-labs-website/response-time-month.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 30d","message":"1171 ms","color":"red"}
+{"schemaVersion":1,"label":"response time 30d","message":"1148 ms","color":"red"}

--- a/api/subspace-labs-website/response-time-week.json
+++ b/api/subspace-labs-website/response-time-week.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 7d","message":"453 ms","color":"yellowgreen"}
+{"schemaVersion":1,"label":"response time 7d","message":"478 ms","color":"yellowgreen"}

--- a/api/subspace-labs-website/response-time-year.json
+++ b/api/subspace-labs-website/response-time-year.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time 1y","message":"1171 ms","color":"red"}
+{"schemaVersion":1,"label":"response time 1y","message":"1148 ms","color":"red"}

--- a/api/subspace-labs-website/response-time.json
+++ b/api/subspace-labs-website/response-time.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"response time","message":"445 ms","color":"yellowgreen"}
+{"schemaVersion":1,"label":"response time","message":"448 ms","color":"yellowgreen"}


### PR DESCRIPTION
Remove the Gemini-2a archive since the droplet was destroyed and we're now using the archive hosted on the [Aquarium](https://app.subsquid.io/archives/gemini-2a-testnet/subsquid)