### PR TITLE
Update Archive API to POST request with body

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -26,10 +26,14 @@ sites:
     url: "squid.gemini-2a.subspace.network/graphql?query=%7B__typename%7D"
   - name: "Gemini-III block explorer squid GraphQL endpoint"
     url: "squid.gemini-3b.subspace.network/graphql?query=%7B__typename%7D"
-  - name: "Gemini-III Subsquid archive API endpoint"
-    url: "archive.gemini-3c.subspace.network/api?query=%7B__typename%7D"
   - name: "Gemini-III Subsquid archive GraphQL endpoint"
-    url: "archive.gemini-3b.subspace.network/graphql?query=%7B__typename%7D"
+    url: "archive.gemini-3c.subspace.network/graphql?query=%7B__typename%7D"
+  - name: "Gemini-III Subsquid archive API endpoint"
+    url: "archive.gemini-3c.subspace.network/api"
+    method: POST
+    headers:
+    - "Content-Type: application/json"
+    body: '{"query":"query { status { head } }"}'
 
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain


### PR DESCRIPTION
`archive.gemini-3c.subspace.network/api` does not support GET request we're using for `/graphql` endpoints, replacing it with POST request with request body to avoid 404